### PR TITLE
Add description method to matchers

### DIFF
--- a/lib/rspec-xml/xml_matchers/have_xpath/matcher.rb
+++ b/lib/rspec-xml/xml_matchers/have_xpath/matcher.rb
@@ -13,6 +13,10 @@ module RSpecXML
           ::Nokogiri::XML(xml).xpath(full_xpath).count > 0
         end
 
+        def description
+          "have xpath #{full_xpath}"
+        end
+
         def failure_message_for_should
           "expected #{full_xpath} to exist" 
         end

--- a/lib/rspec-xml/xml_matchers/have_xpath/text_matcher.rb
+++ b/lib/rspec-xml/xml_matchers/have_xpath/text_matcher.rb
@@ -15,6 +15,10 @@ module RSpecXML
           ::Nokogiri::XML(xml).xpath(xpath).text == text
         end
 
+        def description
+          "have xpath #{xpath} with text #{text}"
+        end
+
         def failure_message_for_should
           "expected #{xpath} to contain #{text}"
         end

--- a/spec/rspec-xml/xml_matchers/have_xpath/matcher_spec.rb
+++ b/spec/rspec-xml/xml_matchers/have_xpath/matcher_spec.rb
@@ -35,4 +35,11 @@ describe RSpecXML::XMLMatchers::HaveXPath::Matcher do
       subject.failure_message_for_should_not.should == "expected xpath to not exist"
     end
   end
+
+  describe '#description' do
+    it 'should return a message describing the xpath matcher' do
+      subject.stubs(:xpath).returns('/expr')
+      subject.description.should == 'have xpath /expr'
+    end
+  end
 end

--- a/spec/rspec-xml/xml_matchers/have_xpath/text_matcher_spec.rb
+++ b/spec/rspec-xml/xml_matchers/have_xpath/text_matcher_spec.rb
@@ -50,4 +50,11 @@ describe RSpecXML::XMLMatchers::HaveXPath::TextMatcher do
     end
   end
 
+  describe '#description' do
+    it 'should return a message describing the text matcher' do
+      subject.stubs(:xpath).returns('/expr')
+      subject.stubs(:text).returns('text')
+      subject.description.should == 'have xpath /expr with text text'
+    end
+  end
 end


### PR DESCRIPTION
RSpec uses the matcher description to describe what the matcher is
testing when the matcher hasn't necessarily failed.
