### PR TITLE
Tolerate multiple nodes at given xpath

### DIFF
--- a/lib/rspec-xml/xml_matchers/have_xpath/attr_matcher.rb
+++ b/lib/rspec-xml/xml_matchers/have_xpath/attr_matcher.rb
@@ -12,10 +12,12 @@ module RSpecXML
         end
 
         def matches?(xml)
-          node = ::Nokogiri::XML(xml).xpath(xpath)
-          !node.empty? && attr.all? do |k, v|
-            attr_value = node.attr(k.to_s)
-            !attr_value.nil? && attr_value.value == v.to_s
+          nodes = ::Nokogiri::XML(xml).xpath(xpath).to_a
+          !nodes.empty? && nodes.any? do |node|
+            attr.all? do |k, v|
+              attr_value = node.attr(k.to_s)
+              !attr_value.nil? && attr_value == v.to_s
+            end
           end
         end
 

--- a/lib/rspec-xml/xml_matchers/have_xpath/text_matcher.rb
+++ b/lib/rspec-xml/xml_matchers/have_xpath/text_matcher.rb
@@ -12,7 +12,7 @@ module RSpecXML
         end
 
         def matches?(xml)
-          ::Nokogiri::XML(xml).xpath(xpath).text == text
+          ::Nokogiri::XML(xml).xpath(xpath).to_a.any? { |e| e.text == text }
         end
 
         def description

--- a/spec/features/steps/have_path_steps.rb
+++ b/spec/features/steps/have_path_steps.rb
@@ -15,7 +15,7 @@ steps_for :have_path do
     @xml = @xml.call "<#{node_name} #{key}=\"#{value}\"></#{node_name}>"
   end
 
-  step 'I test for the attribute: :key to be :value within the :node_name node' do |key, value, node_name|
+  step 'I test for the attributce: :key to be :value within the :node_name node' do |key, value, node_name|
     @test = lambda { expect(@xml).to have_xpath("//#{node_name}").with_attr({key => value}) }
   end
 

--- a/spec/features/steps/have_path_steps.rb
+++ b/spec/features/steps/have_path_steps.rb
@@ -15,7 +15,7 @@ steps_for :have_path do
     @xml = @xml.call "<#{node_name} #{key}=\"#{value}\"></#{node_name}>"
   end
 
-  step 'I test for the attributce: :key to be :value within the :node_name node' do |key, value, node_name|
+  step 'I test for the attribute: :key to be :value within the :node_name node' do |key, value, node_name|
     @test = lambda { expect(@xml).to have_xpath("//#{node_name}").with_attr({key => value}) }
   end
 

--- a/spec/rspec-xml/xml_matchers/have_xpath/attr_matcher_spec.rb
+++ b/spec/rspec-xml/xml_matchers/have_xpath/attr_matcher_spec.rb
@@ -18,8 +18,15 @@ describe RSpecXML::XMLMatchers::HaveXPath::AttrMatcher do
     # TODO mock out Nokogiri
 
     it 'should return true if the supplied xml contains the xpath with supplied attributes' do
-      matcher = subject.class.new(:xpath => '//hi', :attr => {'foo' => 'bar', 'x' => 2})
-      expect(matcher.matches?('<hi foo="bar" x="2"/>')).to be_truthy
+      matcher = subject.class.new(:xpath => '//root/hi', :attr => {'foo' => 'bar', 'x' => 2})
+      expect(matcher.matches?(<<EOS
+      <root>
+          <hi foo="bar" x="1"/>
+          <hi foo="bar" x="2"/>
+          <hi foo="bar" x="3"/>
+      </root>
+EOS
+             )).to be_truthy
     end
 
     it 'should return false if the supplied xml contains the xpath but not the one of the attibutes' do

--- a/spec/rspec-xml/xml_matchers/have_xpath/text_matcher_spec.rb
+++ b/spec/rspec-xml/xml_matchers/have_xpath/text_matcher_spec.rb
@@ -18,8 +18,15 @@ describe RSpecXML::XMLMatchers::HaveXPath::TextMatcher do
     # TODO mock out Nokogiri
 
     it 'should return true if the supplied xml contains the xpath with supplied text' do
-      matcher = subject.class.new(:xpath => '//hi', :text => 'hi')
-      expect(matcher.matches?('<hi>hi</hi>')).to be_truthy
+      matcher = subject.class.new(:xpath => '//root/hi', :text => 'hi')
+      expect(matcher.matches?(<<EOS
+      <root>
+          <hi>hello</hi>
+          <hi>hi</hi>
+          <hi>hey</hi>
+      </root>
+EOS
+             )).to be_truthy
     end
 
     it 'should return false if the supplied xml contains the xpath but not the text' do


### PR DESCRIPTION
* Before, TextMatcher and AttrMatcher would match only the first node
returned by an XPath expression.
* Now, they behave like Enumerable#any? and will return true if any
node returned by the XPath expression matches.

This is the behavior I would expect from `have_xpath`