### PR TITLE
Adding namespaces

### DIFF
--- a/lib/rspec-xml/version.rb
+++ b/lib/rspec-xml/version.rb
@@ -1,3 +1,3 @@
 module RSpecXML
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/lib/rspec-xml/xml_matchers.rb
+++ b/lib/rspec-xml/xml_matchers.rb
@@ -7,15 +7,15 @@ require "#{root}/xml_matchers/have_xpath"
 module RSpecXML
   module XMLMatchers
 
-    def have_xpath(xpath)
-      HaveXPath.new(xpath, self)
+    def have_xpath(xpath, namespaces={})
+      HaveXPath.new(xpath, namespaces, self)
     end
 
     def within(xpath, &example_group_block)
       return unless block_given?
 
       instance_exec(example_group_block) do
-        @xpath_stack ||= [] 
+        @xpath_stack ||= []
         @xpath_stack.push xpath
         yield
         @xpath_stack.pop

--- a/lib/rspec-xml/xml_matchers/have_xpath.rb
+++ b/lib/rspec-xml/xml_matchers/have_xpath.rb
@@ -1,17 +1,19 @@
 module RSpecXML
   module XMLMatchers
     class HaveXPath
-      def initialize(xpath, example_group)
+      def initialize(xpath, namespaces, example_group)
         self.matcher = Matcher.new(
           :xpath => xpath,
-          :example_group => example_group
+          :example_group => example_group,
+          :namespaces => namespaces
         )
       end
 
       def with_text(text)
         self.matcher = TextMatcher.new(
           :xpath => matcher.full_xpath,
-          :text => text.to_s
+          :text => text.to_s,
+          :namespaces => matcher.namespaces
         )
 
         self
@@ -20,7 +22,8 @@ module RSpecXML
       def with_attr(attr)
         self.matcher = AttrMatcher.new(
           :xpath => matcher.full_xpath,
-          :attr => attr
+          :attr => attr,
+          :namespaces => matcher.namespaces
         )
 
         self

--- a/lib/rspec-xml/xml_matchers/have_xpath/attr_matcher.rb
+++ b/lib/rspec-xml/xml_matchers/have_xpath/attr_matcher.rb
@@ -9,10 +9,11 @@ module RSpecXML
         def initialize(options={})
           self.xpath = options[:xpath]
           self.attr = options[:attr]
+          self.namespaces = options[:namespaces]
         end
 
         def matches?(xml)
-          nodes = ::Nokogiri::XML(xml).xpath(xpath).to_a
+          nodes = ::Nokogiri::XML(xml).xpath(xpath, namespaces).to_a
           !nodes.empty? && nodes.any? do |node|
             attr.all? do |k, v|
               attr_value = node.attr(k.to_s)
@@ -35,7 +36,7 @@ module RSpecXML
 
         private
 
-        attr_accessor :attr, :xpath
+        attr_accessor :attr, :xpath, :namespaces
       end
     end
   end

--- a/lib/rspec-xml/xml_matchers/have_xpath/matcher.rb
+++ b/lib/rspec-xml/xml_matchers/have_xpath/matcher.rb
@@ -7,10 +7,11 @@ module RSpecXML
         def initialize(options={})
           self.xpath = options[:xpath]
           self.example_group = options[:example_group]
+          self.namespaces = options[:namespaces]
         end
 
         def matches?(xml)
-          ::Nokogiri::XML(xml).xpath(full_xpath).count > 0
+          ::Nokogiri::XML(xml).xpath(full_xpath, namespaces).count > 0
         end
 
         def description
@@ -30,7 +31,7 @@ module RSpecXML
           xpath_stack.join.concat(xpath)
         end
 
-        attr_accessor :xpath, :example_group
+        attr_accessor :xpath, :example_group, :namespaces
       end
     end
   end

--- a/lib/rspec-xml/xml_matchers/have_xpath/text_matcher.rb
+++ b/lib/rspec-xml/xml_matchers/have_xpath/text_matcher.rb
@@ -9,10 +9,11 @@ module RSpecXML
         def initialize(options={})
           self.xpath = options[:xpath]
           self.text = options[:text]
+          self.namespaces = options[:namespaces]
         end
 
         def matches?(xml)
-          ::Nokogiri::XML(xml).xpath(xpath).to_a.any? { |e| e.text == text }
+          ::Nokogiri::XML(xml).xpath(xpath, namespaces).to_a.any? { |e| e.text == text }
         end
 
         def description
@@ -29,7 +30,7 @@ module RSpecXML
 
         private
 
-        attr_accessor :text, :xpath
+        attr_accessor :text, :xpath, :namespaces
       end
     end
   end

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,20 @@ gem 'rspec-xml'
 "<something>else</something>".should_not have_xpath('/something').with_text('what')
 ```
 
+### Namespaces
+
+```ruby
+# some_spec.rb
+'<something xmlns="http://www.example.com/namespace"><inside>hello</inside></something>'
+  .should_not have_xpath('/something')
+
+'<something xmlns="http://www.example.com/namespace"><inside>hello</inside></something>'
+  .should have_xpath('/ns:something', 'ns' => 'http://www.example.com/namespace')
+
+'<something xmlns="http://www.example.com/namespace"><inside>hello</inside></something>'
+  .should have_xpath('/ns:something/ns:inside', 'ns' => 'http://www.example.com/namespace')
+```
+
 ### Builder
 
 ```ruby

--- a/spec/features/steps/within_steps.rb
+++ b/spec/features/steps/within_steps.rb
@@ -28,4 +28,3 @@ steps_for :within do
     expect(@test).to raise_error(RSpec::Expectations::ExpectationNotMetError)
   end
 end
-

--- a/spec/rspec-xml/xml_matchers/have_xpath/attr_matcher_spec.rb
+++ b/spec/rspec-xml/xml_matchers/have_xpath/attr_matcher_spec.rb
@@ -47,14 +47,14 @@ EOS
     context 'with namespaces' do
       it 'should return true if the supplied xml contains the xpath with supplied attributes' do
         matcher = subject.class.new(:xpath => '//root/hi', :attr => {'foo' => 'bar', 'x' => 2})
-        expect(matcher.matches?(<<EOS
-        <root>
-            <hi foo="bar" x="1"/>
-            <hi foo="bar" x="2"/>
-            <hi foo="bar" x="3"/>
-        </root>
-  EOS
-               )).to be_truthy
+        expect(matcher.matches?(<<-EOS
+          <root>
+              <hi foo="bar" x="1"/>
+              <hi foo="bar" x="2"/>
+              <hi foo="bar" x="3"/>
+          </root>
+          EOS
+        )).to be_truthy
       end
     end
 

--- a/spec/rspec-xml/xml_matchers/have_xpath/attr_matcher_spec.rb
+++ b/spec/rspec-xml/xml_matchers/have_xpath/attr_matcher_spec.rb
@@ -44,6 +44,20 @@ EOS
       expect(matcher.matches?('<no></no>')).to be_falsey
     end
 
+    context 'with namespaces' do
+      it 'should return true if the supplied xml contains the xpath with supplied attributes' do
+        matcher = subject.class.new(:xpath => '//root/hi', :attr => {'foo' => 'bar', 'x' => 2})
+        expect(matcher.matches?(<<EOS
+        <root>
+            <hi foo="bar" x="1"/>
+            <hi foo="bar" x="2"/>
+            <hi foo="bar" x="3"/>
+        </root>
+  EOS
+               )).to be_truthy
+      end
+    end
+
   end
 
   describe '#failure_message' do

--- a/spec/rspec-xml/xml_matchers/have_xpath/matcher_spec.rb
+++ b/spec/rspec-xml/xml_matchers/have_xpath/matcher_spec.rb
@@ -16,9 +16,21 @@ describe RSpecXML::XMLMatchers::HaveXPath::Matcher do
       expect(matcher.matches?('<hi></hi>')).to be_truthy
     end
 
-    it 'should return false if the supplied xml contains the xpath' do
+    it 'should return false if the supplied xml does not contain the xpath' do
       matcher = subject.class.new(:xpath => '//hi')
       expect(matcher.matches?('<no></no>')).to be_falsey
+    end
+  end
+
+  context 'with a namespace in the xml' do
+    it 'should return false if the supplied xml has a namesapce but the xpath does not contain the namespace' do
+      matcher = subject.class.new(:xpath => '//hi')
+      expect(matcher.matches?('<hi xmlns="https://www.example.com/namespace"></hi>')).to be_falsey
+    end
+
+    it 'should return true if the supplied xml has a namespace and the xpath contains the namespace' do
+      matcher = subject.class.new(:xpath => '//a:hi', :namespaces => {:a => 'https://www.example.com/namespace' })
+      expect(matcher.matches?('<hi xmlns="https://www.example.com/namespace"></hi>')).to be_truthy
     end
   end
 

--- a/spec/rspec-xml/xml_matchers/have_xpath/text_matcher_spec.rb
+++ b/spec/rspec-xml/xml_matchers/have_xpath/text_matcher_spec.rb
@@ -39,6 +39,31 @@ EOS
       expect(matcher.matches?('<no></no>')).to be_falsey
     end
 
+    context 'with namespaces' do
+      it 'should return false if the supplied xml has a namesapce but the xpath does not contain the namespace' do
+        matcher = subject.class.new(:xpath => '//root/hi', :text => 'hi')
+        expect(matcher.matches?(<<EOS
+        <root xmlns="http://www.example.com/namespace">
+            <hi>hello</hi>
+            <hi>hi</hi>
+            <hi>hey</hi>
+        </root>
+EOS
+               )).to be_falsey
+      end
+
+      it 'should return true if the supplied xml has a namesapce and the xpath contains the namespace' do
+        matcher = subject.class.new(:xpath => '//ns:root/ns:hi', :text => 'hi', :namespaces => { :ns => 'http://www.example.com/namespace' })
+        expect(matcher.matches?(<<EOS
+        <root xmlns="http://www.example.com/namespace">
+            <hi>hello</hi>
+            <hi>hi</hi>
+            <hi>hey</hi>
+        </root>
+EOS
+               )).to be_truthy
+      end
+    end
   end
 
   describe '#failure_message' do

--- a/spec/rspec-xml/xml_matchers/have_xpath_matcher_spec.rb
+++ b/spec/rspec-xml/xml_matchers/have_xpath_matcher_spec.rb
@@ -4,8 +4,8 @@ module Factory
   def self.example_group
     @example_group ||= Class.new
   end
-  def self.xpath_matcher(xpath)
-    RSpecXML::XMLMatchers::HaveXPath.new(xpath, example_group)
+  def self.xpath_matcher(xpath, namespaces = {})
+    RSpecXML::XMLMatchers::HaveXPath.new(xpath, namespaces, example_group)
   end
 end
 
@@ -13,14 +13,14 @@ describe RSpecXML::XMLMatchers::HaveXPath do
   let(:example_group) { Factory.example_group }
 
   describe '#intialize' do
-    it 'should build and save a matcher containing the supplied xpath' do
+    it 'should build and save a matcher containing the supplied xpath and namespaces' do
 
       RSpecXML::XMLMatchers::HaveXPath::Matcher.
         expects(:new).
-        with(:xpath => 'fake xpath', :example_group => example_group).
+        with(:xpath => 'fake xpath', :namespaces => { :a => 'https://www.example.com/namespace' }, :example_group => example_group).
         returns(:flag)
 
-      xpath_matcher = Factory.xpath_matcher('fake xpath')
+      xpath_matcher = Factory.xpath_matcher('fake xpath', :a => 'https://www.example.com/namespace')
       expect(xpath_matcher.send(:matcher)).to eq :flag
 
     end
@@ -31,7 +31,7 @@ describe RSpecXML::XMLMatchers::HaveXPath do
 
       RSpecXML::XMLMatchers::HaveXPath::TextMatcher.
         expects(:new).
-        with(:xpath => 'fake xpath', :text => 'blah').
+        with(:xpath => 'fake xpath', :text => 'blah', :namespaces => {}).
         returns(:flag)
 
       xpath_matcher = Factory.xpath_matcher('fake xpath').with_text('blah')
@@ -45,7 +45,7 @@ describe RSpecXML::XMLMatchers::HaveXPath do
 
       RSpecXML::XMLMatchers::HaveXPath::AttrMatcher.
         expects(:new).
-        with(:xpath => 'fake xpath', :attr => {"name" => "John Doe"}).
+        with(:xpath => 'fake xpath', :attr => {"name" => "John Doe"}, :namespaces => {}).
         returns(:flag)
 
       xpath_matcher = Factory.xpath_matcher('fake xpath').with_attr({"name" => "John Doe"})


### PR DESCRIPTION
Support of namespaces is added to all matchers. Usage of namespaces os optional so that there are no breaking api changes. Specs and examples are included and namespaces are documented in the README.
