### PR TITLE
Allow matchers to be composed

### DIFF
--- a/lib/rspec-xml/xml_matchers/have_xpath.rb
+++ b/lib/rspec-xml/xml_matchers/have_xpath.rb
@@ -1,6 +1,8 @@
 module RSpecXML
   module XMLMatchers
     class HaveXPath
+      include RSpec::Matchers::Composable
+
       def initialize(xpath, example_group)
         self.matcher = Matcher.new(
           :xpath => xpath,


### PR DESCRIPTION
Using these matchers to create helper methods is greatly enhanced by allowing a helper method to impose multiple conditions using 'and'.

I have just included the RSpec mixin Composable to allow this.
